### PR TITLE
Fix: Code in 3rd-party packages is not being transformed by reactify

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/webRunes/Login-WRIO-App/issues"
   },
   "homepage": "https://github.com/webRunes/Login-WRIO-App",
+  "browserify": {
+    "transform": ["reactify"]
+  },
   "dependencies": {
     "aws-sdk-apis": "*",
     "body-parser": "1.7.0",


### PR DESCRIPTION
https://github.com/andreypopp/reactify#code-in-3rd-party-packages-isnt-being-transformed-by-reactify